### PR TITLE
ENH: Ensure that bulk events and event_pages work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - pip install .
   # Install extra requirements for running tests and building docs.
   - pip install -r requirements-dev.txt
+  - pip install -U git+https://github.com/NSLS-II/event-model.git
 
 script:
   - coverage run -m pytest  # Run the tests and check for test coverage.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # List required packages in this file, one per line.
+event-model
 pandas

--- a/suitcase/csv/__init__.py
+++ b/suitcase/csv/__init__.py
@@ -85,13 +85,18 @@ def export(gen, filepath, **kwargs):
                 for event_page in event_pages:
                     if not all(event_page['filled'].values()):
                         # check that all event_page data is filled
-                        raise UnfilledDataException('some of the data is' +
-                                                    ' unfilled')
+                        unfilled_data = []
+                        for field in event_page['filled']:
+                            if not event_page['filled'][field]:
+                                unfilled_data.append(field)
+                        raise UnfilledData('unfilled data found in'
+                                           '{}. Try passing the parameter '
+                                           '"gen" through "event_model.filler"'
+                                           ' first'.format(unfilled_data))
                     else:
-                        data_dict = event_page['data']
-                        data_dict['seq_num'] = event_page['seq_num']
-                        event_data = pandas.DataFrame(data_dict,
+                        event_data = pandas.DataFrame(event_page['data'],
                                                       index=event_page['time'])
+                        event_data['seq_num'] = event_page['seq_num']
 
                         if initial_header_kwarg:
                             kwargs['header'] = event_page['descriptor'] \
@@ -109,6 +114,6 @@ def export(gen, filepath, **kwargs):
     return (f.name,) + tuple(f.name for f in files.values())
 
 
-class UnfilledDataException(Exception):
+class UnfilledData(Exception):
     """raised when unfilled data is found"""
     pass

--- a/suitcase/csv/__init__.py
+++ b/suitcase/csv/__init__.py
@@ -1,26 +1,29 @@
-# Suitcase subpackages must follow strict naming and interface conventions. The
-# public API should include some subset of the following. Any functions not
+# suitcase subpackages must follow strict naming and interface conventions. the
+# public api should include some subset of the following. any functions not
 # implemented should be omitted, rather than included and made to raise
-# NotImplementError, so that a client importing this library can immediately
-# know which portions of the suitcase API it supports without calling any
+# notimplementerror, so that a client importing this library can immediately
+# know which portions of the suitcase api it supports without calling any
 # functions.
 #
 from collections import defaultdict
 import itertools
 import json
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions
+import pandas
+#from ._version import get_versions
+
+#__version__ = get_versions()['version']
+#
+#del get_versions
 
 
-def export(gen, filepath):
+def export(gen, filepath, **kwargs):
     """
-    Export a stream of documents to CSV file(s) and one JSON file of metadata.
+    export a stream of documents to csv file(s) and one json file of metadata.
 
-    Creates {filepath}_meta.json and then {filepath}_{stream_name}.csv
-    for every Event stream.
+    creates {filepath}_meta.json and then {filepath}_{stream_name}.csv
+    for every event stream.
 
-    The structure of the json is::
+    the structure of the json is::
 
         {'start': {...},
         'descriptors':
@@ -28,53 +31,67 @@ def export(gen, filepath):
             ...},
         'stop': {...}}
 
-    Parameters
+    both event and bulk_event are supported.
+
+    event/bulk_event data found in doc['timestamp'] is not exported, only the
+    time(s) recorded in doc['time'].
+
+    parameters
     ----------
     gen : generator
         expected to yield (name, document) pairs
     filepath : str
 
-    Returns
+    **kwargs : kwargs
+        kwargs to be passed to pandas.DataFrame.to_csv.
+
+    returns
     -------
     dest : tuple
         filepaths of generated files
     """
-    meta = {}  # to be exported as JSON at the end
+    meta = {}  # to be exported as json at the end
     meta['descriptors'] = defaultdict(list)  # map stream_name to descriptors
-    files = {}  # map descriptor uid to file handle of CSV file
+    files = {}  # map descriptor uid to file handle of csv file
     desc_counters = defaultdict(itertools.count)
+    has_header = []  # a list of uids indicating if the file has a header.
     try:
         for name, doc in gen:
             if name == 'start':
                 if 'start' in meta:
-                    raise RuntimeError("This exporter expects documents from "
+                    raise runtimeerror("this exporter expects documents from "
                                        "one run only.")
                 meta['start'] = doc
             elif name == 'stop':
                 meta['stop'] = doc
             elif name == 'descriptor':
-                stream_name = doc.get('name')
+                stream_name = doc['name']
                 meta['descriptors'][stream_name].append(doc)
                 filepath_ = (f"{filepath}_{stream_name}_"
                              f"{next(desc_counters[doc['uid']])}.csv")
                 files[doc['uid']] = open(filepath_, 'w+')
-            elif name == 'event':
-                row = ', '.join(map(str, (doc['time'], *doc['data'].values())))
-                f = files[doc['descriptor']]
-                f.write(f'{row}\n')
+            elif name == 'event' or name == 'bulk_event':
+            #note: this also works for bulk_events, it relies on
+            # doc['data']['some_key'] and doc['time'] both being either a value
+            # or a list of the same length.
+                if name == 'event':
+                    index = [doc['time']]
+                else:
+                    index = doc['time']
+                event_data = pandas.dataframe(doc['data'], index=index)
+            # check if we need to add headers to the file
+                if doc['descriptor'] in has_header:
+                    header = false
+                else:
+                    header = true
+                    has_header.append(doc['descriptor'])
+
+                event_data.to_csv(files[doc['descriptor']], mode='a',
+                                  header=header, **kwargs)
+
     finally:
         for f in files.values():
             f.close()
     with open(f"{filepath}_meta.json", 'w') as f:
         json.dump(meta, f)
     return (f.name,) + tuple(f.name for f in files.values())
-#
-# def ingest(...):
-#     ...
-#
-#
-# def reflect(...):
-#     ...
-#
-#
-# handlers = []

--- a/suitcase/csv/__init__.py
+++ b/suitcase/csv/__init__.py
@@ -8,14 +8,13 @@
 from collections import defaultdict
 import itertools
 import json
-import pandas
-#from ._version import get_versions
+from ._version import get_versions
 
-#__version__ = get_versions()['version']
-#del get_versions
+__version__ = get_versions()['version']
+del get_versions
 
 
-def export(gen, filepath, **kwargs):
+def export(gen, filepath):
     """
     Export a stream of documents to CSV file(s) and one JSON file of metadata.
 
@@ -36,13 +35,7 @@ def export(gen, filepath, **kwargs):
     ----------
     gen : generator
         expected to yield (name, document) pairs
-
     filepath : str
-        the filepath and filename suffix to use in the output files.
-
-    **kwargs : kwargs
-        kwargs to be passed to pandas.Dataframe.to_csv, NOTE: header and 'mode'
-        kwargs are not supported as they have default values.
 
     Returns
     -------
@@ -53,14 +46,14 @@ def export(gen, filepath, **kwargs):
     meta['descriptors'] = defaultdict(list)  # map stream_name to descriptors
     files = {}  # map descriptor uid to file handle of CSV file
     desc_counters = defaultdict(itertools.count)
-    has_header = set()  # a set of uids indicating if the file has a header
+    has_header = set() # a set of uids indicating if the file has a header
 
     if 'header' in kwargs or 'mode' in kwargs:
         raise IllegalArgumentError('`header` and `mode` are set by default'+
                                    ' and can not be passed in via keyword'+
                                    'arguments')
 
-    try:
+try:
         for name, doc in gen:
             if name == 'start':
                 if 'start' in meta:
@@ -90,13 +83,9 @@ def export(gen, filepath, **kwargs):
                                   **kwargs)
                 has_header.add(doc['descriptor'])
 
-    finally:
+     finally:
         for f in files.values():
             f.close()
     with open(f"{filepath}_meta.json", 'w') as f:
         json.dump(meta, f)
     return (f.name,) + tuple(f.name for f in files.values())
-
-
-class IllegalArgumentError(ValueError):
-    pass

--- a/suitcase/csv/__init__.py
+++ b/suitcase/csv/__init__.py
@@ -89,9 +89,13 @@ def export(gen, filepath, **kwargs):
                         for field in event_page['filled']:
                             if not event_page['filled'][field]:
                                 unfilled_data.append(field)
+                        # Note: As of this writing, this is a slightly
+                        # aspirational error message, as event_model.Filler has
+                        # not been merged yet. May need to be revisited if it
+                        # is renamed or kept elsewhere in the end.
                         raise UnfilledData('unfilled data found in'
                                            '{}. Try passing the parameter '
-                                           '"gen" through "event_model.filler"'
+                                           '"gen" through "event_model.Filler"'
                                            ' first'.format(unfilled_data))
                     else:
                         event_data = pandas.DataFrame(event_page['data'],

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -34,9 +34,10 @@ def test_export(RE, hw):
     start, descriptor, *events, stop = docs
 
     expected = {}
-    expected_dict = {'data': {'det': []}, 'time': []}
+    expected_dict = {'data': {'det': [], 'seq_num': []}, 'time': []}
     for event in events:
         expected_dict['data']['det'].append(event['data']['det'])
+        expected_dict['data']['seq_num'].append(event['seq_num'])
         expected_dict['time'].append(event['time'])
 
     expected['events'] = pandas.DataFrame(expected_dict['data'],

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -45,9 +45,21 @@ def test_export(RE, hw):
 
     with open(meta) as f:
         actual = json.load(f)
+    # This next section is used to convert lists to tuples for the assert below
+    for dims in actual['start']['hints']['dimensions']:
+        new_dims = []
+        for dim in dims:
+            if type(dim) is list:
+                new_dims.append(tuple(dim))
+            else:
+                new_dims.append(dim)
+        actual['start']['hints']['dimensions'] = [tuple(new_dims)]
+
     expected.update({'start': start, 'stop': stop,
-                     'descriptors': [descriptor]})
+                     'descriptors': {'primary': [descriptor]}})
     actual['events'] = pandas.read_csv(csv, index_col=0)
     assert actual.keys() == expected.keys()
+    assert actual['start'] == expected['start']
+    assert actual['descriptors'] == expected['descriptors']
     assert actual['stop'] == expected['stop']
     assert_frame_equal(expected['events'], actual['events'])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5,6 +5,7 @@ import json
 import tempfile
 from suitcase.csv import export
 import pandas
+import event_model
 from pandas.util.testing import assert_frame_equal
 import numpy as np
 
@@ -16,7 +17,9 @@ def generate_csv(fh, num_rows=1, num_columns=1, delimiter=','):
     df.to_csv(path_or_buf=fh, sep=delimiter)
 
 
-def test_export(RE, hw):
+def test_export_events(RE, hw):
+    '''Test to see if the suitcase.csv.export works on events.
+    '''
     collector = []
 
     def collect(name, doc):
@@ -32,6 +35,123 @@ def test_export(RE, hw):
 
     docs = (doc for name, doc in collector)
     start, descriptor, *events, stop = docs
+
+    expected = {}
+    expected_dict = {'data': {'det': [], 'seq_num': []}, 'time': []}
+    for event in events:
+        expected_dict['data']['det'].append(event['data']['det'])
+        expected_dict['data']['seq_num'].append(event['seq_num'])
+        expected_dict['time'].append(event['time'])
+
+    expected['events'] = pandas.DataFrame(expected_dict['data'],
+                                          index=expected_dict['time'])
+    expected['events'].index.name = 'time'
+
+    with open(meta) as f:
+        actual = json.load(f)
+    # This next section is used to convert lists to tuples for the assert below
+    for dims in actual['start']['hints']['dimensions']:
+        new_dims = []
+        for dim in dims:
+            if type(dim) is list:
+                new_dims.append(tuple(dim))
+            else:
+                new_dims.append(dim)
+        actual['start']['hints']['dimensions'] = [tuple(new_dims)]
+
+    expected.update({'start': start, 'stop': stop,
+                     'descriptors': {'primary': [descriptor]}})
+    actual['events'] = pandas.read_csv(csv, index_col=0)
+    assert actual.keys() == expected.keys()
+    assert actual['start'] == expected['start']
+    assert actual['descriptors'] == expected['descriptors']
+    assert actual['stop'] == expected['stop']
+    assert_frame_equal(expected['events'], actual['events'])
+
+
+def test_export_bulk_event(RE, hw):
+    '''Test to see if suitcase.csv.export() works on bulk_events
+    '''
+    collector = []
+    events = []
+
+    def collect(name, doc):
+        if name == 'event':
+            events.append(doc)
+        elif name == 'stop':
+            collector.append(('bulk_event', {'primary': events}))
+            collector.append((name, doc))
+        else:
+            collector.append((name, doc))
+
+    RE.subscribe(collect)
+    RE(count([hw.det], 5))
+
+    with tempfile.NamedTemporaryFile(mode='w') as f:
+        # We don't actually need f itself, just a filepath to template on.
+        meta, *csvs = export(collector, f.name)
+    csv, = csvs
+
+    docs = (doc for name, doc in collector)
+    start, descriptor, *bulk_events, stop = docs
+
+    expected = {}
+    expected_dict = {'data': {'det': [], 'seq_num': []}, 'time': []}
+    for event in events:
+        expected_dict['data']['det'].append(event['data']['det'])
+        expected_dict['data']['seq_num'].append(event['seq_num'])
+        expected_dict['time'].append(event['time'])
+
+    expected['events'] = pandas.DataFrame(expected_dict['data'],
+                                          index=expected_dict['time'])
+    expected['events'].index.name = 'time'
+
+    with open(meta) as f:
+        actual = json.load(f)
+    # This next section is used to convert lists to tuples for the assert below
+    for dims in actual['start']['hints']['dimensions']:
+        new_dims = []
+        for dim in dims:
+            if type(dim) is list:
+                new_dims.append(tuple(dim))
+            else:
+                new_dims.append(dim)
+        actual['start']['hints']['dimensions'] = [tuple(new_dims)]
+
+    expected.update({'start': start, 'stop': stop,
+                     'descriptors': {'primary': [descriptor]}})
+    actual['events'] = pandas.read_csv(csv, index_col=0)
+    assert actual.keys() == expected.keys()
+    assert actual['start'] == expected['start']
+    assert actual['descriptors'] == expected['descriptors']
+    assert actual['stop'] == expected['stop']
+    assert_frame_equal(expected['events'], actual['events'])
+
+
+def test_export_event_page(RE, hw):
+    collector = []
+    events = []
+
+    def collect(name, doc):
+        if name == 'event':
+            events.append(doc)
+        elif name == 'stop':
+            collector.append(('event_page',
+                              event_model.pack_event_page(*events)))
+            collector.append((name, doc))
+        else:
+            collector.append((name, doc))
+
+    RE.subscribe(collect)
+    RE(count([hw.det], 5))
+
+    with tempfile.NamedTemporaryFile(mode='w') as f:
+        # We don't actually need f itself, just a filepath to template on.
+        meta, *csvs = export(collector, f.name)
+    csv, = csvs
+
+    docs = (doc for name, doc in collector)
+    start, descriptor, *event_pages, stop = docs
 
     expected = {}
     expected_dict = {'data': {'det': [], 'seq_num': []}, 'time': []}


### PR DESCRIPTION
This would deprecate PR#1, it removes all of the import functionality (as it has been decided that suitcase will not import). It also appends each event to the file in the for loop to minimize issues with memory caused by large data sets.

It has been tested manually, with both bulk and single events, and includes an updated and working pytest function.