### PR TITLE
FIX: fix ophyd branch for testing; add readme content type

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ codecov
 coverage
 flake8
 # TEMPORARY UNTIL https://github.com/NSLS-II/ophyd/pull/682 IS RELEASED
-git+git://github.com/awalter-bnl/ophyd@add-configure
+git+git://github.com/NSLS-II/ophyd@ophyd-for-suitcase-utils
 pytest >=3.9
 sphinx
 suitcase-utils[test_fixtures] >=0.1.0rc2

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     long_description=readme,
+    long_description_content_type='text/markdown',
     packages=['suitcase.csv'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Fixes:
- ophyd branch for testing;
- readme content type (https://github.com/NSLS-II/suitcase-utils/pull/21).